### PR TITLE
drivers: modem: clean function hang indentation whitespace

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -46,7 +46,7 @@ static void skipcrlf(struct modem_cmd_handler_data *data)
 }
 
 static uint16_t findcrlf(struct modem_cmd_handler_data *data,
-		      struct net_buf **frag, uint16_t *offset)
+			 struct net_buf **frag, uint16_t *offset)
 {
 	struct net_buf *buf = data->rx_buf;
 	uint16_t len = 0U, pos = 0U;
@@ -180,7 +180,7 @@ static int parse_params(struct modem_cmd_handler_data *data,  size_t match_len,
 
 /* process a "matched" command */
 static int process_cmd(const struct modem_cmd *cmd, size_t match_len,
-			struct modem_cmd_handler_data *data)
+		       struct modem_cmd_handler_data *data)
 {
 	int parsed_len = 0, ret = 0;
 	uint8_t *argv[CONFIG_MODEM_CMD_HANDLER_MAX_PARAM_COUNT];
@@ -221,8 +221,7 @@ static int process_cmd(const struct modem_cmd *cmd, size_t match_len,
  * - unsolicited handlers[1]
  * - current assigned handlers[2]
  */
-static const struct modem_cmd *find_cmd_match(
-		struct modem_cmd_handler_data *data)
+static const struct modem_cmd *find_cmd_match(struct modem_cmd_handler_data *data)
 {
 	int j;
 	size_t i;
@@ -646,8 +645,8 @@ void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler)
 }
 
 int modem_cmd_handler_init(struct modem_cmd_handler *handler,
-			      struct modem_cmd_handler_data *data,
-			      const struct modem_cmd_handler_setup *setup)
+			   struct modem_cmd_handler_data *data,
+			   const struct modem_cmd_handler_setup *setup)
 {
 	/* Verify arguments */
 	if (NULL == handler || NULL == data || NULL == setup) {

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -312,8 +312,8 @@ struct modem_cmd_handler_setup {
  * @return -EINVAL if any argument is invalid, 0 if successful
  */
 int modem_cmd_handler_init(struct modem_cmd_handler *handler,
-			      struct modem_cmd_handler_data *data,
-			      const struct modem_cmd_handler_setup *setup);
+			   struct modem_cmd_handler_data *data,
+			   const struct modem_cmd_handler_setup *setup);
 
 /**
  * @brief  Lock the modem for sending cmds
@@ -359,7 +359,7 @@ void modem_cmd_handler_tx_unlock(struct modem_cmd_handler *handler);
  * @param iface The interface which receives incoming data
  */
 static inline void modem_cmd_handler_process(struct modem_cmd_handler *handler,
-			      struct modem_iface *iface)
+					     struct modem_iface *iface)
 {
 	handler->process(handler, iface);
 }

--- a/drivers/modem/modem_context.c
+++ b/drivers/modem/modem_context.c
@@ -20,7 +20,9 @@ LOG_MODULE_REGISTER(modem_context, CONFIG_MODEM_LOG_LEVEL);
 
 static struct modem_context *contexts[CONFIG_MODEM_CONTEXT_MAX_NUM];
 
-int modem_context_sprint_ip_addr(const struct sockaddr *addr, char *buf, size_t buf_size)
+int modem_context_sprint_ip_addr(const struct sockaddr *addr,
+				 char *buf,
+				 size_t buf_size)
 {
 	static const char unknown_str[] = "unk";
 

--- a/drivers/modem/modem_context.h
+++ b/drivers/modem/modem_context.h
@@ -80,7 +80,9 @@ struct modem_context {
  *
  * @retval 0 if ok, < 0 if error.
  */
-int modem_context_sprint_ip_addr(const struct sockaddr *addr, char *buf, size_t buf_size);
+int modem_context_sprint_ip_addr(const struct sockaddr *addr,
+				 char *buf,
+				 size_t buf_size);
 
 /**
  * @brief  Get port from IP address

--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -64,8 +64,8 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
  * @return 0 if successful
  */
 int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_data *data,
-			      char *rx_rb_buf, size_t rx_rb_buf_len, const struct device *dev,
-			      bool hw_flow_control);
+			  char *rx_rb_buf, size_t rx_rb_buf_len, const struct device *dev,
+			  bool hw_flow_control);
 
 /**
  * @brief Wait for rx data ready from uart interface
@@ -76,7 +76,8 @@ int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_dat
  * @return -EBUSY if returned without waiting
  * @return -EAGAIN if timeout occurred
  */
-static inline int modem_iface_uart_rx_wait(struct modem_iface *iface, k_timeout_t timeout)
+static inline int modem_iface_uart_rx_wait(struct modem_iface *iface,
+					   k_timeout_t timeout)
 {
 	return k_sem_take(&((struct modem_iface_uart_data *)(iface->iface_data))->rx_sem, timeout);
 }

--- a/drivers/modem/modem_iface_uart_async.c
+++ b/drivers/modem/modem_iface_uart_async.c
@@ -149,8 +149,8 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 }
 
 int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_data *data,
-			char *rx_rb_buf, size_t rx_rb_buf_len, const struct device *dev,
-			bool hw_flow_control)
+			  char *rx_rb_buf, size_t rx_rb_buf_len, const struct device *dev,
+			  bool hw_flow_control)
 {
 	int ret;
 

--- a/drivers/modem/modem_iface_uart_interrupt.c
+++ b/drivers/modem/modem_iface_uart_interrupt.c
@@ -199,8 +199,8 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 }
 
 int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_data *data,
-			char *rx_rb_buf, size_t rx_rb_buf_len, const struct device *dev,
-			bool hw_flow_control)
+			  char *rx_rb_buf, size_t rx_rb_buf_len, const struct device *dev,
+			  bool hw_flow_control)
 {
 	int ret;
 

--- a/drivers/modem/modem_socket.h
+++ b/drivers/modem/modem_socket.h
@@ -101,8 +101,8 @@ void modem_socket_data_ready(struct modem_socket_config *cfg, struct modem_socke
  * @return 0 if successful
  */
 int modem_socket_init(struct modem_socket_config *cfg, struct modem_socket *sockets,
-			      size_t sockets_len, int base_socket_id, bool assign_id,
-			      const struct socket_op_vtable *vtable);
+		      size_t sockets_len, int base_socket_id, bool assign_id,
+		      const struct socket_op_vtable *vtable);
 
 /**
  * @brief Check if modem socket has been allocated
@@ -131,7 +131,7 @@ bool modem_socket_is_allocated(const struct modem_socket_config *cfg,
  * @return true if the socket id is been assigned, otherwise false
  */
 bool modem_socket_id_is_assigned(const struct modem_socket_config *cfg,
-			      const struct modem_socket *sock);
+				 const struct modem_socket *sock);
 
 /**
  * @brief Assign id to modem socket
@@ -144,7 +144,8 @@ bool modem_socket_id_is_assigned(const struct modem_socket_config *cfg,
  * @return -EINVAL if id is invalid
  */
 int modem_socket_id_assign(const struct modem_socket_config *cfg,
-			      struct modem_socket *sock, int id);
+			   struct modem_socket *sock,
+			   int id);
 
 #ifdef __cplusplus
 }

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -2148,7 +2148,7 @@ static int modem_init(const struct device *dev)
 
 	/* socket config */
 	ret = modem_socket_init(&mdata.socket_config, &mdata.sockets[0], ARRAY_SIZE(mdata.sockets),
-			   MDM_BASE_SOCKET_NUM, false, &offload_socket_fd_op_vtable);
+				MDM_BASE_SOCKET_NUM, false, &offload_socket_fd_op_vtable);
 	if (ret < 0) {
 		goto error;
 	}


### PR DESCRIPTION
Many of the functions in throughout the modem headers had strange and inconsistent whitespace for hang indentation in function declarations and invocations. These have been aligned with using tab widths of 8 and spaces to make up the remaining gaps.